### PR TITLE
Less restrictive gem dependencies

### DIFF
--- a/SassyBitwise.gemspec
+++ b/SassyBitwise.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.6}
 
   # Gems Dependencies
-  s.add_dependency("sass",      ["~> 3.3"])
-  s.add_dependency("compass",   ["~> 0.12"])
+  s.add_dependency("sass",      [">= 3.3"])
+  s.add_dependency("compass",   [">=1.0.0.alpha.18"])
 end


### PR DESCRIPTION
Set Sass 3.3 as a _minimum_ requirement, and since Sass 3.3 needs Compass 1.0.0.alpha.18, set that as well. See https://github.com/HugoGiraudel/SassyStrings/blob/master/SassyStrings.gemspec#L34-L35 for an example.
